### PR TITLE
1.1.0 Beta 3

### DIFF
--- a/Continuum Launcher/Game1.cs
+++ b/Continuum Launcher/Game1.cs
@@ -886,7 +886,10 @@ namespace XeniaLauncher
             {
                 try
                 {
-                    File.Copy(xeniaPath, "XData\\Xenia\\" + newTitle + "\\xenia.exe");
+                    if (!gameData[index].preferCanary)
+                    {
+                        File.Copy(xeniaPath, "XData\\Xenia\\" + newTitle + "\\xenia.exe");
+                    }
                 }
                 catch { }
                 try
@@ -900,9 +903,16 @@ namespace XeniaLauncher
             {
                 startInfo.FileName = xeniaPath;
             }
-            Process.Start(startInfo);
-
-            OpenCompatWindow(false, compatWindowDelay);
+            try
+            {
+                Process.Start(startInfo);
+                OpenCompatWindow(false, compatWindowDelay);
+            }
+            catch
+            {
+                message = new MessageWindow(this, "Error", "Unable to launch Xenia", state);
+                state = State.Message;
+            }
         }
         public void LaunchXenia()
         {
@@ -923,7 +933,10 @@ namespace XeniaLauncher
             {
                 try
                 {
-                    File.Copy(canaryPath, "XData\\Canary\\" + newTitle + "\\xenia_canary.exe");
+                    if (!gameData[index].preferCanary)
+                    {
+                        File.Copy(canaryPath, "XData\\Canary\\" + newTitle + "\\xenia_canary.exe");
+                    }
                 }
                 catch { }
                 try
@@ -937,80 +950,20 @@ namespace XeniaLauncher
             {
                 startInfo.FileName = canaryPath;
             }
-            Process.Start(startInfo);
-
-            OpenCompatWindow(true, compatWindowDelay);
+            try
+            {
+                Process.Start(startInfo);
+                OpenCompatWindow(false, compatWindowDelay);
+            }
+            catch
+            {
+                message = new MessageWindow(this, "Error", "Unable to launch Canary", state);
+                state = State.Message;
+            }
         }
         public void LaunchCanary()
         {
             LaunchCanary(gameData[index].gamePath);
-        }
-        public void DefaultQuickstart(string path)
-        {
-            launchSound.Play();
-            if (gameData[index].preferCanary)
-            {
-                ProcessStartInfo startInfo = new ProcessStartInfo();
-                startInfo.Arguments = "\"" + path + "\"";
-                string title = gameData[index].gameTitle;
-                string newTitle = GetFilepathString(title);
-                startInfo.WorkingDirectory = "XData\\Canary\\" + newTitle;
-                Directory.CreateDirectory("XData\\Canary\\" + newTitle);
-                if (consolidateFiles)
-                {
-                    try
-                    {
-                        File.Copy(canaryPath, "XData\\Canary\\" + newTitle + "\\xenia_canary.exe");
-                    }
-                    catch { }
-                    try
-                    {
-                        File.Create("XData\\Canary\\" + newTitle + "\\portable.txt");
-                    }
-                    catch { }
-                    startInfo.FileName = "XData\\Canary\\" + newTitle + "\\xenia_canary.exe";
-                }
-                else
-                {
-                    startInfo.FileName = canaryPath;
-                }
-                Process.Start(startInfo);
-                OpenCompatWindow(true, compatWindowDelay);
-            }
-            else
-            {
-                ProcessStartInfo startInfo = new ProcessStartInfo();
-                startInfo.Arguments = "\"" + path + "\"";
-                string title = gameData[index].gameTitle;
-                string newTitle = GetFilepathString(title);
-                startInfo.WorkingDirectory = "XData\\Xenia\\" + newTitle;
-                Directory.CreateDirectory("XData\\Xenia\\" + newTitle);
-                if (consolidateFiles)
-                {
-                    try
-                    {
-                        File.Copy(xeniaPath, "XData\\Xenia\\" + newTitle + "\\xenia.exe");
-                    }
-                    catch { }
-                    try
-                    {
-                        File.Create("XData\\Xenia\\" + newTitle + "\\portable.txt");
-                    }
-                    catch { }
-                    startInfo.FileName = "XData\\Xenia\\" + newTitle + "\\xenia.exe";
-                }
-                else
-                {
-                    startInfo.FileName = xeniaPath;
-                }
-                Process.Start(startInfo);
-
-                OpenCompatWindow(false, compatWindowDelay);
-            }
-        }
-        public void DefaultQuickstart()
-        {
-            DefaultQuickstart(gameData[index].gamePath);
         }
         public void EditGame()
         {
@@ -1667,87 +1620,95 @@ namespace XeniaLauncher
             if (messageYes && toDelete != null)
             {
                 string fileTitle = GetFilepathString(masterData[selectedDataIndex].gameTitle);
-                if (toDelete.name.Contains("Xenia {Temporary Copy}"))
+                try
                 {
-                    if (File.Exists("XData\\Xenia\\" + fileTitle + "\\xenia.exe"))
+                    if (toDelete.name.Contains("Xenia {Temporary Copy}"))
                     {
-                        File.Delete("XData\\Xenia\\" + fileTitle + "\\xenia.exe");
-                    }
-                    if (File.Exists("XData\\Xenia\\" + fileTitle + "\\xenia.log"))
-                    {
-                        File.Delete("XData\\Xenia\\" + fileTitle + "\\xenia.log");
-                    }
-                    if (File.Exists("XData\\Xenia\\" + fileTitle + "\\xenia.config.toml"))
-                    {
-                        File.Delete("XData\\Xenia\\" + fileTitle + "\\xenia.config.toml");
-                    }
-                }
-                else if (toDelete.name.Contains("Xenia Canary {Temporary Copy}"))
-                {
-                    if (File.Exists("XData\\Canary\\" + fileTitle + "\\xenia_canary.exe"))
-                    {
-                        File.Delete("XData\\Canary\\" + fileTitle + "\\xenia_canary.exe");
-                    }
-                    if (File.Exists("XData\\Canary\\" + fileTitle + "\\xenia.log"))
-                    {
-                        File.Delete("XData\\Canary\\" + fileTitle + "\\xenia.log");
-                    }
-                    if (File.Exists("XData\\Canary\\" + fileTitle + "\\xenia-canary.config.toml"))
-                    {
-                        File.Delete("XData\\Canary\\" + fileTitle + "\\xenia-canary.config.toml");
-                    }
-                }
-                else if (toDelete.name.Contains("Save Data (Xenia)"))
-                {
-                    if (Directory.Exists("XData\\Xenia\\" + fileTitle + "\\content"))
-                    {
-                        foreach (string filepath in Directory.GetFiles("XData\\Xenia\\" + fileTitle + "\\content", "", SearchOption.AllDirectories))
+                        if (File.Exists("XData\\Xenia\\" + fileTitle + "\\xenia.exe"))
                         {
-                            File.Delete(filepath);
+                            File.Delete("XData\\Xenia\\" + fileTitle + "\\xenia.exe");
                         }
-                        Directory.Delete("XData\\Xenia\\" + fileTitle + "\\content", true);
-                    }
-                }
-                else if (toDelete.name.Contains("Save Data (Canary)"))
-                {
-                    string dir = "XData\\Canary\\" + fileTitle + "\\content\\" + masterData[selectedDataIndex].titleId + "\\profile";
-                    if (Directory.Exists(dir))
-                    {
-                        foreach (string filepath in Directory.GetFiles(dir, "", SearchOption.AllDirectories))
+                        if (File.Exists("XData\\Xenia\\" + fileTitle + "\\xenia.log"))
                         {
-                            File.Delete(filepath);
+                            File.Delete("XData\\Xenia\\" + fileTitle + "\\xenia.log");
                         }
-                        Directory.Delete(dir, true);
-                    }
-                }
-                else if (toDelete.name.Contains("Installed DLC"))
-                {
-                    string dir = "XData\\Canary\\" + masterData[selectedDataIndex].gameTitle + "\\content\\" + masterData[selectedDataIndex].titleId + "\\00000002";
-                    dir = GetFilepathString(dir, true);
-                    if (Directory.Exists(dir))
-                    {
-                        foreach (string filepath in Directory.GetFiles(dir, "", SearchOption.AllDirectories))
+                        if (File.Exists("XData\\Xenia\\" + fileTitle + "\\xenia.config.toml"))
                         {
-                            File.Delete(filepath);
+                            File.Delete("XData\\Xenia\\" + fileTitle + "\\xenia.config.toml");
                         }
-                        Directory.Delete(dir, true);
                     }
-                }
-                else if (toDelete.name.Contains("Installed Title Update"))
-                {
-                    string dir = "XData\\Canary\\" + masterData[selectedDataIndex].gameTitle + "\\content\\" + masterData[selectedDataIndex].titleId + "\\000B0000";
-                    dir = GetFilepathString(dir, true);
-                    if (Directory.Exists(dir))
+                    else if (toDelete.name.Contains("Xenia Canary {Temporary Copy}"))
                     {
-                        foreach (string filepath in Directory.GetFiles(dir, "", SearchOption.AllDirectories))
+                        if (File.Exists("XData\\Canary\\" + fileTitle + "\\xenia_canary.exe"))
                         {
-                            File.Delete(filepath);
+                            File.Delete("XData\\Canary\\" + fileTitle + "\\xenia_canary.exe");
                         }
-                        Directory.Delete(dir, true);
+                        if (File.Exists("XData\\Canary\\" + fileTitle + "\\xenia.log"))
+                        {
+                            File.Delete("XData\\Canary\\" + fileTitle + "\\xenia.log");
+                        }
+                        if (File.Exists("XData\\Canary\\" + fileTitle + "\\xenia-canary.config.toml"))
+                        {
+                            File.Delete("XData\\Canary\\" + fileTitle + "\\xenia-canary.config.toml");
+                        }
                     }
+                    else if (toDelete.name.Contains("Save Data (Xenia)"))
+                    {
+                        if (Directory.Exists("XData\\Xenia\\" + fileTitle + "\\content"))
+                        {
+                            foreach (string filepath in Directory.GetFiles("XData\\Xenia\\" + fileTitle + "\\content", "", SearchOption.AllDirectories))
+                            {
+                                File.Delete(filepath);
+                            }
+                            Directory.Delete("XData\\Xenia\\" + fileTitle + "\\content", true);
+                        }
+                    }
+                    else if (toDelete.name.Contains("Save Data (Canary)"))
+                    {
+                        string dir = "XData\\Canary\\" + fileTitle + "\\content\\" + masterData[selectedDataIndex].titleId + "\\profile";
+                        if (Directory.Exists(dir))
+                        {
+                            foreach (string filepath in Directory.GetFiles(dir, "", SearchOption.AllDirectories))
+                            {
+                                File.Delete(filepath);
+                            }
+                            Directory.Delete(dir, true);
+                        }
+                    }
+                    else if (toDelete.name.Contains("Installed DLC"))
+                    {
+                        string dir = "XData\\Canary\\" + masterData[selectedDataIndex].gameTitle + "\\content\\" + masterData[selectedDataIndex].titleId + "\\00000002";
+                        dir = GetFilepathString(dir, true);
+                        if (Directory.Exists(dir))
+                        {
+                            foreach (string filepath in Directory.GetFiles(dir, "", SearchOption.AllDirectories))
+                            {
+                                File.Delete(filepath);
+                            }
+                            Directory.Delete(dir, true);
+                        }
+                    }
+                    else if (toDelete.name.Contains("Installed Title Update"))
+                    {
+                        string dir = "XData\\Canary\\" + masterData[selectedDataIndex].gameTitle + "\\content\\" + masterData[selectedDataIndex].titleId + "\\000B0000";
+                        dir = GetFilepathString(dir, true);
+                        if (Directory.Exists(dir))
+                        {
+                            foreach (string filepath in Directory.GetFiles(dir, "", SearchOption.AllDirectories))
+                            {
+                                File.Delete(filepath);
+                            }
+                            Directory.Delete(dir, true);
+                        }
+                    }
+                    message = new MessageWindow(this, "File Deleted", "The file was successfully deleted", State.Data);
+                    state = State.Message;
                 }
-                message = new MessageWindow(this, "File Deleted", "The file was successfully deleted", State.Data);
-                state = State.Message;
+                catch
+                {
+                    message = new MessageWindow(this, "Error", "Unable to delete file. It may currently be in use", State.Data);
+                    state = State.Message;
+                }
                 messageYes = false;
                 toDelete = null;
             }
@@ -1839,19 +1800,51 @@ namespace XeniaLauncher
                 {
                     if (gameInfoWindow.buttonIndex == 0 && gameData[index].gameTitle != textWindowInput)
                     {
-                        if (arts.ContainsKey(gameData[index].gameTitle))
+                        bool continueRename = true;
+                        try
                         {
-                            arts.Add(textWindowInput, arts[gameData[index].gameTitle]);
-                            arts.Remove(gameData[index].gameTitle);
+                            // Renaming the game's content folders
+                            if (Directory.Exists("XData\\Xenia\\" + gameData[index].gameTitle))
+                            {
+                                Directory.Move("XData\\Xenia\\" + gameData[index].gameTitle, "XData\\Xenia\\" + textWindowInput);
+                            }
+                            if (Directory.Exists("XData\\Canary\\" + gameData[index].gameTitle))
+                            {
+                                Directory.Move("XData\\Canary\\" + gameData[index].gameTitle, "XData\\Canary\\" + textWindowInput);
+                            }
                         }
-                        else
+                        catch
                         {
-                            arts.Add(textWindowInput, white);
+                            continueRename = false;
+                            message = new MessageWindow(this, "Error", "File IO Error: Unable to rename content folders", State.GameInfo);
+                            state = State.Message;
                         }
-                        gameData[index].gameTitle = textWindowInput;
-                        gameInfoWindow.titleSprite.text = "Info for " + textWindowInput;
-                        gameManageWindow.titleSprite.text = "Manage " + textWindowInput;
-                        SaveGames();
+                        // Continuing if folder renaming was successful
+                        if (continueRename)
+                        {
+                            if (arts.ContainsKey(gameData[index].gameTitle))
+                            {
+                                arts.Add(textWindowInput, arts[gameData[index].gameTitle]);
+                                arts.Remove(gameData[index].gameTitle);
+                            }
+                            else
+                            {
+                                arts.Add(textWindowInput, white);
+                            }
+                            if (icons.ContainsKey(gameData[index].gameTitle))
+                            {
+                                icons.Add(textWindowInput, icons[gameData[index].gameTitle]);
+                                icons.Remove(gameData[index].gameTitle);
+                            }
+                            else
+                            {
+                                icons.Add(textWindowInput, white);
+                            }
+                            gameData[index].gameTitle = textWindowInput;
+                            gameInfoWindow.titleSprite.text = "Info for " + textWindowInput;
+                            gameManageWindow.titleSprite.text = "Manage " + textWindowInput;
+                            SaveGames();
+                        }
                         textWindowInput = null;
                     }
                     else if (gameInfoWindow.buttonIndex == 1)

--- a/Continuum Launcher/GameLaunch.cs
+++ b/Continuum Launcher/GameLaunch.cs
@@ -50,6 +50,7 @@ namespace XeniaLauncher
             else
             {
                 game.message = new MessageWindow(game, "Error", "Provided filepath to Xenia does not exist", Game1.State.Select);
+                game.state = Game1.State.Message;
             }
         }
         /// <summary>
@@ -75,40 +76,7 @@ namespace XeniaLauncher
             else
             {
                 game.message = new MessageWindow(game, "Error", "Provided filepath to Xenia Canary does not exist", Game1.State.Select);
-            }
-        }
-        /// <summary>
-        /// Attemps to launch Xenia or Canary, depending on the config, throwing an error message if it can't
-        /// </summary>
-        public static void SafeQuickstart(Game1 game)
-        {
-            SafeQuickstart(game, "");
-        }
-        public static void SafeQuickstart(Game1 game, string path)
-        {
-            if ((game.gameData[game.index].preferCanary && File.Exists(game.canaryPath)) || (!game.gameData[game.index].preferCanary && File.Exists(game.xeniaPath)))
-            {
-                if (String.IsNullOrEmpty(path))
-                {
-                    game.DefaultQuickstart();
-                }
-                else
-                {
-                    game.DefaultQuickstart(path);
-                }
-            }
-            else
-            {
-                if (game.gameData[game.index].preferCanary)
-                {
-                    game.message = new MessageWindow(game, "Error", "Provided filepath to Xenia Canary does not exist", Game1.State.Select);
-                    game.state = Game1.State.Message;
-                }
-                else
-                {
-                    game.message = new MessageWindow(game, "Error", "Provided filepath to Xenia does not exist", Game1.State.Select);
-                    game.state = Game1.State.Message;
-                }
+                game.state = Game1.State.Message;
             }
         }
         public void ActivateButton(Game1 game, Window source, ObjectSprite origin, int buttonIndex)

--- a/Continuum Launcher/ManageDataEffects.cs
+++ b/Continuum Launcher/ManageDataEffects.cs
@@ -87,7 +87,7 @@ namespace XeniaLauncher
                 }
 
                 // Getting the data of the selected game
-                GameData data = game.gameData[buttonIndex];
+                GameData data = game.masterData[buttonIndex];
                 float size = 0;
                 DirectoryInfo directoryInfo = new DirectoryInfo(data.gamePath).Parent;
                 DirectoryInfo parent = directoryInfo.Parent;

--- a/Continuum Launcher/Shared.cs
+++ b/Continuum Launcher/Shared.cs
@@ -12,8 +12,8 @@ namespace XeniaLauncher
     using DataType = Shared.SaveData.DataType;
     public static class Shared
     {
-        public static readonly string VERSION = "1.1.0 Beta 2";
-        public static readonly string COMPILED = "December 17, 2023";
+        public static readonly string VERSION = "1.1.0 Beta 3";
+        public static readonly string COMPILED = "December 20, 2023";
         public static readonly Dictionary<string, string> contentTypes = new Dictionary<string, string>() {
             { "00000001", "Saved Game"  },
             { "00000002", "Downloadable Content" },

--- a/Continuum Launcher/XEXLaunch.cs
+++ b/Continuum Launcher/XEXLaunch.cs
@@ -35,10 +35,6 @@ namespace XeniaLauncher
                 {
                     GameLaunch.SafeLaunchCanary(game);
                 }
-                else if (game.launchWindow.buttonIndex == 2)
-                {
-                    GameLaunch.SafeQuickstart(game);
-                }
             }
             // Last button is the exit button
             else if (buttonIndex == source.strings.Count - 1)
@@ -56,10 +52,6 @@ namespace XeniaLauncher
                 else if (game.launchWindow.buttonIndex == 1)
                 {
                     GameLaunch.SafeLaunchCanary(game, game.gameData[game.index].xexPaths[buttonIndex - 1]);
-                }
-                else if (game.launchWindow.buttonIndex == 2)
-                {
-                    GameLaunch.SafeQuickstart(game, game.gameData[game.index].xexPaths[buttonIndex - 1]);
                 }
             }
         }

--- a/Continuum Launcher/XeniaGameSettings.cs
+++ b/Continuum Launcher/XeniaGameSettings.cs
@@ -58,7 +58,7 @@ namespace XeniaLauncher
             else if (buttonIndex == 2 || buttonIndex == 3)
             {
                 game.gameData[game.index].preferCanary = !game.gameData[game.index].preferCanary;
-                AdjustCanary(game, source);
+                AdjustCanary(game, source, false);
                 game.SaveGames();
             }
             else if (buttonIndex == 4 || buttonIndex == 5)
@@ -157,7 +157,7 @@ namespace XeniaLauncher
                 sprite.color = Color.FromNonPremultiplied(255, 255, 255, 0);
             }
             AdjustLicense(game, window);
-            AdjustCanary(game, window);
+            AdjustCanary(game, window, true);
             AdjustMountCache(game, window);
             AdjustReadback(game, window);
             AdjustHRes(game, window);
@@ -179,14 +179,20 @@ namespace XeniaLauncher
             source.extraSprites[0].ToTextSprite().text = "License Mask: " + license;
             source.extraSprites[0].Centerize(new Vector2(615, 380));
         }
-        private void AdjustCanary(Game1 game, Window source)
+        private void AdjustCanary(Game1 game, Window source, bool first)
         {
             string canary = "No";
             if (game.gameData[game.index].preferCanary)
             {
                 canary = "Yes";
+                if (!first)
+                {
+                    game.message = new MessageWindow(game, "Note", "This setting disables part of Continuum's launch process. When enabled, Xenia executables must be manually copied to the XData folder", Game1.State.GameXeniaSettings);
+                    game.state = Game1.State.Message;
+                }
             }
-            source.extraSprites[1].ToTextSprite().text = "Prefer Canary: " + canary;
+            source.extraSprites[1].ToTextSprite().text = "Allow Custom Builds: " + canary;
+            source.extraSprites[1].ToTextSprite().scale = 0.5f;
             source.extraSprites[1].Centerize(new Vector2(615, 480));
         }
         private void AdjustMountCache(Game1 game, Window source)


### PR DESCRIPTION
- Replaced the "Prefer Canary" option with a new "Allow Custom Builds" option. When enabled, Continuum will not copy Xenia executables to the game's XData folder, meaning the user will have to provide one themselves
- Fixed a bug where the Manage Games window couldn't open if a game's name was changed in the current session
- Fixed a bug where Sorting would affect how the Manage Games window imported files
- Continuum no longer crashes if unable to launch a game
- Continuum no longer crashes if unable to delete a file in the Manage Games window
- Renaming a game now renames the game's XData folder as well
- The "Provided filepath to Xenia/Canary" error message window now properly appears